### PR TITLE
Potential fix for code scanning alert no. 62: Missing rate limiting

### DIFF
--- a/Routes/account.routes.js
+++ b/Routes/account.routes.js
@@ -13,6 +13,12 @@ import deleteController from '../Controllers/delete.controller.js';
 import editPasswordController from '../Controllers/editPassword.controller.js';
 import userJWTDTO from '../DTO/userJWTDTO.js';
 import editNameController from '../Controllers/editName.controller.js';
+import rateLimit from 'express-rate-limit';
+
+const limiter = rateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 100, // limit each IP to 100 requests per windowMs
+});
 
 const AccountRouter = express.Router()
 
@@ -35,7 +41,7 @@ AccountRouter.put('/update-email/:idAccount', userJWTDTO, editEmailController)
 
 AccountRouter.put('/update-password/:idAccount', userJWTDTO, editPasswordController)
 
-AccountRouter.put('/update-name/:idAccount', userJWTDTO, editNameController)
+AccountRouter.put('/update-name/:idAccount', limiter, userJWTDTO, editNameController)
 
 AccountRouter.delete('/delete/:idAccount', userJWTDTO, deleteController)
 

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "styled-components": "^6.1.14",
     "util": "^0.12.5",
     "uuid": "^11.1.0",
-    "uuid-parse": "^1.1.0"
+    "uuid-parse": "^1.1.0",
+    "express-rate-limit": "^7.5.0"
   },
   "devDependencies": {
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",


### PR DESCRIPTION
Potential fix for [https://github.com/Linmake/Text-notes/security/code-scanning/62](https://github.com/Linmake/Text-notes/security/code-scanning/62)

To fix the problem, we need to introduce rate limiting to the route handler that performs authorization. The best way to do this is by using the `express-rate-limit` package, which allows us to easily set up rate limiting middleware. We will configure the rate limiter to allow a maximum of 100 requests per 15 minutes and apply it to the specific route handler.

1. Install the `express-rate-limit` package.
2. Import the `express-rate-limit` package in the `Routes/account.routes.js` file.
3. Configure the rate limiter with the desired settings.
4. Apply the rate limiter to the route handler that performs authorization.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
